### PR TITLE
Update 1.3_Image_similarity_metrics.ipynb

### DIFF
--- a/docs/source/reader/1.3_Image_similarity_metrics.ipynb
+++ b/docs/source/reader/1.3_Image_similarity_metrics.ipynb
@@ -94,7 +94,7 @@
     "Bayes’ rule is a very useful formula that we will use later in the computer-aided diagnosis notebooks of this course. \n",
     "The so-called Bayes' theorem gives the probability of an event based on new information that is, or may be related, to that event. Mathematically, the Bayes' theorem can be expressed as follow: \n",
     "\n",
-    "$p_{X|Y} = \\frac{p_{Y|X}(x|y)p_{Y}(y)}{p_{X}(x)}$   ,\n",
+    "$p_{X|Y} = \\frac{p_{Y|X}(x|y)p_{X}(x)}{p_{Y}(y)}$   ,\n",
     "\n",
     "where $X$ and $Y$ are events and $P(Y) \\neq 0$, and:\n",
     "\n",


### PR DESCRIPTION
Edit Bayes’ rule. P_{Y}(y) must appear in denominator, that is why  P_{Y}(y) != 0.